### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- resolved cookstyle error: providers/smartproxy.rb:52:3 convention: `Style/RedundantCondition`
 ## 0.0.2 - *2021-06-01*
 
 - Adopted by Sous-Chefs

--- a/providers/smartproxy.rb
+++ b/providers/smartproxy.rb
@@ -49,13 +49,9 @@ def api
 end
 
 def proxy
-  if @proxy
-    @proxy
-  else
-    @proxy = api.call(:index,
+  @proxy || @proxy = api.call(:index,
                       # rubocop:disable Layout/LineLength
                       search: "name=#{new_resource.smartproxy_name}")['results'][0]
-  end
 end
 
 def id


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.17.0 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with providers/smartproxy.rb

 - 52:3 convention: `Style/RedundantCondition` - Use double pipes `||` instead.